### PR TITLE
Validate the files that can be uploaded on the Multimedia Repository

### DIFF
--- a/assets/config/opensrp.properties
+++ b/assets/config/opensrp.properties
@@ -84,3 +84,6 @@ schedule.location.add.serverVersion.interval=120000
 schedule.openmrs.sync.interval=300000
 schedule.openmrs.validate.interval=420000
 schedule.dhis2.sync.interval=600000
+
+#Allowed MIME Types
+multimedia.allowed.file.types=application/octet-stream,image/jpeg,image/gif,image/png


### PR DESCRIPTION
Issue # 276
Support configuration that will allow restriction on file types that can be uploaded.
The mime-types can be restricted using configs on the opensrp.properties file