### PR TITLE
Migrate Redis configs to java

### DIFF
--- a/modules/core/applicationContext-opensrp.xml
+++ b/modules/core/applicationContext-opensrp.xml
@@ -66,45 +66,4 @@
 		<import resource="persistence_postgres.xml" />
 	</beans>
 
-	<beans profile="jedis">
-		<bean id="jedisPoolConfig" class="redis.clients.jedis.JedisPoolConfig"
-			p:max-total="${redis.pool.max.connections}" p:test-on-borrow="true"
-			p:test-on-return="true" />
-
-		<bean id="jedisConnectionFactory"
-			class="org.springframework.data.redis.connection.jedis.JedisConnectionFactory"
-			p:host-name="${redis.host}" p:port="${redis.port}" p:password="${redis.password}"
-			p:use-pool="true">
-			<constructor-arg ref="jedisPoolConfig" />
-		</bean>
-
-		<bean id="redisTemplate" class="org.springframework.data.redis.core.RedisTemplate"
-			p:connection-factory-ref="jedisConnectionFactory"
-			p:enable-transaction-support="true" />
-	</beans>
-
-	<beans profile="lettuce">
-		<bean id="lettucePool"
-			class="org.springframework.data.redis.connection.lettuce.DefaultLettucePool">
-			<property name="hostName" value="${redis.host}" />
-			<property name="port" value="${redis.port}" />
-			<property name="password" value="${redis.password}" />
-			<property name="poolConfig" ref="lettucePoolConfiguration" />
-		</bean>
-
-		<bean id="lettucePoolConfiguration" class="org.springframework.data.redis.connection.PoolConfig"
-			p:max-total="${redis.pool.max.connections}" p:test-on-borrow="true"
-			p:test-on-return="true" />
-
-		<bean id="lettuceConnectionFactory"
-			class="org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory">
-			<constructor-arg index="0" ref="lettucePool" />
-		</bean>
-
-		<bean id="redisTemplate" class="org.springframework.data.redis.core.RedisTemplate"
-			p:connection-factory-ref="lettuceConnectionFactory"
-			p:enable-transaction-support="true" />
-			
-	</beans>
-
 </beans>


### PR DESCRIPTION
- [x] Redis configs are now configured with builders which are difficult to configure via XML.

- [x] This PR moves the Redis configs to Java so that modern API for redis connection configs can be used