### PR TITLE
Add migrations for Practitioner and Organization tables to add server_version date_created/edited timestamps

### DIFF
--- a/assets/migrations/scripts/20211206083056_add_practitioner_and_orgs_columns_date_created_date_edited_server_version.sql
+++ b/assets/migrations/scripts/20211206083056_add_practitioner_and_orgs_columns_date_created_date_edited_server_version.sql
@@ -1,0 +1,26 @@
+-- // add practitioner and orgs columns date created date edited server version
+-- Migration SQL that makes the change goes here.
+
+-- Add date created and date edited columns
+ALTER TABLE team.practitioner ADD COLUMN IF NOT EXISTS date_created timestamp DEFAULT NOW();
+ALTER TABLE team.practitioner ADD COLUMN IF NOT EXISTS date_edited timestamp DEFAULT NOW();
+ALTER TABLE team.organization ADD COLUMN IF NOT EXISTS date_created timestamp DEFAULT NOW();
+ALTER TABLE team.organization ADD COLUMN IF NOT EXISTS date_edited timestamp DEFAULT NOW();
+
+-- Add server version columns
+ALTER TABLE team.practitioner ADD COLUMN IF NOT EXISTS server_version bigint;
+ALTER TABLE team.organization ADD COLUMN IF NOT EXISTS server_version bigint;
+
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE team.practitioner DROP COLUMN date_created;
+ALTER TABLE team.practitioner DROP COLUMN date_edited;
+ALTER TABLE team.organization DROP COLUMN date_created;
+ALTER TABLE team.organization DROP COLUMN date_edited;
+
+ALTER TABLE team.organization DROP COLUMN server_version;
+ALTER TABLE team.organization DROP COLUMN server_version;
+
+

--- a/assets/migrations/scripts/20211206103520_add_practitioner_and_organization_sequences.sql
+++ b/assets/migrations/scripts/20211206103520_add_practitioner_and_organization_sequences.sql
@@ -1,0 +1,16 @@
+-- // add practitioner and organization sequences
+-- Migration SQL that makes the change goes here.
+--Create Sequences
+CREATE SEQUENCE IF NOT EXISTS team.practitioner_server_version_seq;
+CREATE SEQUENCE IF NOT EXISTS team.organization_server_version_seq;
+
+--populate sequences with Max server versions
+SELECT setval('team.practitioner_server_version_seq',(SELECT max(server_version )+1 FROM team.practitioner));
+SELECT setval('team.organization_server_version_seq',(SELECT max(server_version )+1 FROM team.organization));
+
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+DROP SEQUENCE IF EXISTS team.practitioner_server_version_seq;
+DROP SEQUENCE IF EXISTS team.organization_server_version_seq;
+

--- a/assets/migrations/scripts/20211222125217_add_server_versions_for_existing_practitioners_and_organizations.sql
+++ b/assets/migrations/scripts/20211222125217_add_server_versions_for_existing_practitioners_and_organizations.sql
@@ -1,0 +1,20 @@
+-- // add server versions for existing practitioners and organizations
+-- Migration SQL that makes the change goes here.
+
+
+-- Update server version
+update team.practitioner set server_version = nextval('team.practitioner_server_version_seq')
+where server_version IS NULL;
+
+update team.organization set server_version = nextval('team.organization_server_version_seq')
+where server_version IS NULL;
+
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+update team.practitioner set server_version = NULL
+where server_version IS NOT NULL;
+
+update team.organization set server_version = NULL
+where server_version IS NOT NULL;


### PR DESCRIPTION
Added migrations scripts to add:
- server version, date created/edited columns
- server version sequences
- server versions for existing records


---
See https://github.com/opensrp/opensrp-server-core/issues/521 for details