### PR TITLE
fix order of migrations scripts

### DIFF
--- a/assets/migrations/scripts/20211212101151_copy_add_practitioner_and_orgs_columns_date_created_date_edited_server_version.sql
+++ b/assets/migrations/scripts/20211212101151_copy_add_practitioner_and_orgs_columns_date_created_date_edited_server_version.sql
@@ -1,0 +1,26 @@
+-- // add practitioner and orgs columns date created date edited server version
+-- Migration SQL that makes the change goes here.
+
+-- Add date created and date edited columns
+ALTER TABLE team.practitioner ADD COLUMN IF NOT EXISTS date_created timestamp DEFAULT NOW();
+ALTER TABLE team.practitioner ADD COLUMN IF NOT EXISTS date_edited timestamp DEFAULT NOW();
+ALTER TABLE team.organization ADD COLUMN IF NOT EXISTS date_created timestamp DEFAULT NOW();
+ALTER TABLE team.organization ADD COLUMN IF NOT EXISTS date_edited timestamp DEFAULT NOW();
+
+-- Add server version columns
+ALTER TABLE team.practitioner ADD COLUMN IF NOT EXISTS server_version bigint;
+ALTER TABLE team.organization ADD COLUMN IF NOT EXISTS server_version bigint;
+
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE team.practitioner DROP COLUMN date_created;
+ALTER TABLE team.practitioner DROP COLUMN date_edited;
+ALTER TABLE team.organization DROP COLUMN date_created;
+ALTER TABLE team.organization DROP COLUMN date_edited;
+
+ALTER TABLE team.organization DROP COLUMN server_version;
+ALTER TABLE team.organization DROP COLUMN server_version;
+
+

--- a/assets/migrations/scripts/20211212110051_copy_add_practitioner_and_organization_sequences.sql
+++ b/assets/migrations/scripts/20211212110051_copy_add_practitioner_and_organization_sequences.sql
@@ -1,0 +1,16 @@
+-- // add practitioner and organization sequences
+-- Migration SQL that makes the change goes here.
+--Create Sequences
+CREATE SEQUENCE IF NOT EXISTS team.practitioner_server_version_seq;
+CREATE SEQUENCE IF NOT EXISTS team.organization_server_version_seq;
+
+--populate sequences with Max server versions
+SELECT setval('team.practitioner_server_version_seq',(SELECT max(server_version )+1 FROM team.practitioner));
+SELECT setval('team.organization_server_version_seq',(SELECT max(server_version )+1 FROM team.organization));
+
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+DROP SEQUENCE IF EXISTS team.practitioner_server_version_seq;
+DROP SEQUENCE IF EXISTS team.organization_server_version_seq;
+


### PR DESCRIPTION
- Order change on scripts 
    - [add_practitioner_and_orgs_columns_date_created_date_edited_server_version.sql](https://github.com/opensrp/opensrp-server-configs/blob/master/assets/migrations/scripts/20211206083056_add_practitioner_and_orgs_columns_date_created_date_edited_server_version.sql) and  
    - [add_practitioner_and_organization_sequences.sql](https://github.com/opensrp/opensrp-server-configs/blob/master/assets/migrations/scripts/20211206103520_add_practitioner_and_organization_sequences.sql)
affects upgrade from [v2.8.44](https://github.com/opensrp/opensrp-server-web/releases/tag/v2.8.44-SNAPSHOT) to any release after it due to some missing columns.

[Server Configs for v2.8.44](https://github.com/opensrp/opensrp-server-configs/tree/a9ea5e8d94c0b7e7ea24d8893109caccef02483c/assets/migrations/scripts) and [after](https://github.com/opensrp/opensrp-server-configs/tree/master/assets/migrations/scripts)  