### PR TITLE
mark issued unique ids as used

### DIFF
--- a/assets/migrations/scripts/20211123172925_set_issued_unique_ids_as_used.sql
+++ b/assets/migrations/scripts/20211123172925_set_issued_unique_ids_as_used.sql
@@ -1,0 +1,25 @@
+--
+--    Copyright 2010-2016 the original author or authors.
+--
+--    Licensed under the Apache License, Version 2.0 (the "License");
+--    you may not use this file except in compliance with the License.
+--    You may obtain a copy of the License at
+--
+--       http://www.apache.org/licenses/LICENSE-2.0
+--
+--    Unless required by applicable law or agreed to in writing, software
+--    distributed under the License is distributed on an "AS IS" BASIS,
+--    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--    See the License for the specific language governing permissions and
+--    limitations under the License.
+--
+
+-- // set issued unique ids as used
+-- Migration SQL that makes the change goes here.
+
+UPDATE core.unique_id SET status = 'used' WHERE status ='not_used';
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+


### PR DESCRIPTION
Migration to set the status of all generated Unique IDs as used to prevent clients from having duplicate zeirIds